### PR TITLE
Add auth passthrough

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.5.2
+    rev: v1.5.3
     hooks:
       - id: autopep8
   - repo: https://gitlab.com/pycqa/flake8
-    rev: '3.8.2'
+    rev: '3.8.3'
     hooks:
       - id: flake8
         args: [--max-line-length=120]

--- a/pacifica/dispatcher_k8s/config.py
+++ b/pacifica/dispatcher_k8s/config.py
@@ -22,6 +22,13 @@ def get_local_scripts(script_dir):
 def get_config():
     """Return the ConfigParser object with defaults set."""
     configparser = ConfigParser()
+    configparser.add_section('authentication')
+    configparser.set('authentication', 'type', getenv(
+        'AUTHENTICATION_TYPE', 'basic'))
+    configparser.set('authentication', 'username', getenv(
+        'AUTHENTICATION_USERNAME', None))
+    configparser.set('authentication', 'password', getenv(
+        'AUTHENTICATION_PASSWORD', None))
     configparser.add_section('database')
     configparser.set('database', 'peewee_url', getenv(
         'PEEWEE_URL', 'sqlite:///db.sqlite3'))

--- a/pacifica/dispatcher_k8s/eventhandler.py
+++ b/pacifica/dispatcher_k8s/eventhandler.py
@@ -15,6 +15,7 @@ from jsonpath2.path import Path
 from cloudevents.model import Event
 from pacifica.downloader import Downloader
 from pacifica.uploader import Uploader
+from pacifica.cli.methods import generate_requests_auth
 from pacifica.dispatcher.models import File, Transaction, TransactionKeyValue
 from pacifica.dispatcher.event_handlers import EventHandler
 from pacifica.dispatcher.downloader_runners import DownloaderRunner, RemoteDownloaderRunner
@@ -134,12 +135,13 @@ def generate_eventhandler(script_config):
 
 def make_routes():
     """Make the routes in the router."""
+    auth_obj = generate_requests_auth(get_config())
     for script in get_config().options('dispatcher_k8s_scripts'):
         script_config = get_script_config(get_config(), script)
         ROUTER.add_route(
             # pylint: disable=no-member
             Path.parse_str(script_config.router_jsonpath),
             generate_eventhandler(script_config)(
-                RemoteDownloaderRunner(Downloader()), RemoteUploaderRunner(Uploader())
+                RemoteDownloaderRunner(Downloader(**auth_obj)), RemoteUploaderRunner(Uploader(**auth_obj))
             )
         )

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 coverage
-pacifica-cli
 peewee
 pep257
 pre-commit

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
         'celery',
         'cherrypy',
         'peewee',
+        'pacifica-cli',
         'pacifica-dispatcher',
         'eventlet'
     ]


### PR DESCRIPTION
### Description

This passes through the Auth parsed from the CLI method to generate
the requests auth object.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
