### PR TITLE
The Defaults Must be Strings

### DIFF
--- a/pacifica/dispatcher_k8s/config.py
+++ b/pacifica/dispatcher_k8s/config.py
@@ -26,9 +26,9 @@ def get_config():
     configparser.set('authentication', 'type', getenv(
         'AUTHENTICATION_TYPE', 'basic'))
     configparser.set('authentication', 'username', getenv(
-        'AUTHENTICATION_USERNAME', None))
+        'AUTHENTICATION_USERNAME', ''))
     configparser.set('authentication', 'password', getenv(
-        'AUTHENTICATION_PASSWORD', None))
+        'AUTHENTICATION_PASSWORD', ''))
     configparser.add_section('database')
     configparser.set('database', 'peewee_url', getenv(
         'PEEWEE_URL', 'sqlite:///db.sqlite3'))


### PR DESCRIPTION
The defaults for config parser should be a string not None

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
