### PR TITLE
Update Logging Logic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.5.3
+    rev: v1.5.4
     hooks:
       - id: autopep8
   - repo: https://gitlab.com/pycqa/flake8
@@ -9,7 +9,7 @@ repos:
       - id: flake8
         args: [--max-line-length=120]
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.1.0
+    rev: v3.2.0
     hooks:
       - id: fix-encoding-pragma
       - id: trailing-whitespace
@@ -51,7 +51,7 @@ repos:
         language: system
         types: [python]
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.7
+    rev: v1.1.9
     hooks:
       - id: remove-tabs
       - id: remove-crlf

--- a/pacifica/dispatcher_k8s/eventhandler.py
+++ b/pacifica/dispatcher_k8s/eventhandler.py
@@ -58,7 +58,7 @@ def generate_eventhandler(script_config):
 
         def _handle_download(self, event: Event) -> None:
             """Handle the download of the data to the download directory."""
-            output_path = os.path.join(script_config.data_dir, event.event_id, 'output')
+            output_path = os.path.join(script_config.data_dir, event.event_id, script_config.output_dirs[0].directory)
             down_path = os.path.join(script_config.data_dir, event.event_id, 'download')
             if os.path.isdir(down_path):  # pragma: no cover just sanity condition should never happen
                 rmtree(down_path)
@@ -108,16 +108,15 @@ def generate_eventhandler(script_config):
             transaction_inst = Transaction.from_cloudevents_model(event)
             for upload_config in script_config.output_dirs:
                 upload_dir = os.path.join(script_config.data_dir, event.event_id, upload_config.directory)
-                with _redirect_stdout_stderr(upload_dir):
-                    (_bundle, _job_id, _state) = self.uploader_runner.upload(
-                        upload_dir,
-                        transaction=Transaction(
-                            submitter=transaction_inst.submitter,
-                            instrument=transaction_inst.instrument,
-                            project=transaction_inst.project
-                        ),
-                        transaction_key_values=self._parse_csv_file(upload_dir, upload_config)
-                    )
+                (_bundle, _job_id, _state) = self.uploader_runner.upload(
+                    upload_dir,
+                    transaction=Transaction(
+                        submitter=transaction_inst.submitter,
+                        instrument=transaction_inst.instrument,
+                        project=transaction_inst.project
+                    ),
+                    transaction_key_values=self._parse_csv_file(upload_dir, upload_config)
+                )
 
         def handle(self, event: Event) -> None:
             """


### PR DESCRIPTION
### Description

This removes the upload logging, that's a bit nonsensical. And
fix the download log to save to the first upload directory instead
of hard coded 'output' directory.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
